### PR TITLE
add support to disable admin folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,22 @@ RUN set -xe \
 RUN set -xe \
     && ln -sf /usr/share/zoneinfo/${MANTIS_TIMEZONE} /etc/localtime \
     && echo 'date.timezone = "${MANTIS_TIMEZONE}"' > /usr/local/etc/php/php.ini
+
+
+ENV DPE_SHA1 d59ca12d89616c1bccb7769df5b9b97fb5a9a98c
+ENV DPE docker-php-entrypoint
+ENV NDPE new-docker-php-entrypoint
+ENV ODPE old-docker-php-entrypoint
+
+COPY admin-disable-snippet /usr/local/bin
+
+RUN set -xe \
+    && cd /usr/local/bin \
+    && echo "${DPE_SHA1} ${DPE}" | sha1sum -c || (echo "Upstream ${DPE} files has changed, verify this script." && exit 1 ) \
+    && head -n-1 $DPE > $NDPE \
+    && cat admin-disable-snippet >> $NDPE \
+    && tail -n1 $DPE >> $NDPE \
+    && mv $DPE $ODPE \
+    && mv $NDPE $DPE \
+    && chmod 775 $DPE
+

--- a/README.md
+++ b/README.md
@@ -70,3 +70,13 @@ $g_smtp_connection_mode = 'tls';
 $g_smtp_username = 'mantisbt';
 $g_smtp_password = '********';
 ```
+
+## Disabling admin folder
+
+MantisBT recommends to disable access to the admin folder once the initial
+configuration has been done.
+
+Do to so, set the environment variable `DISABLE_ADMIN_FOLDER` in your
+container startscript of `docker-compose.yml` to `true`.
+
+

--- a/admin-disable-snippet
+++ b/admin-disable-snippet
@@ -1,0 +1,6 @@
+if [ "$DISABLE_ADMIN_FOLDER" = "true" ]; then
+  chmod 000 /var/www/html/admin
+  echo "Access to admin folder disabled"
+fi
+
+


### PR DESCRIPTION
Here we go, split my old pull request into two, this is part one: "support to disable admin folder". The entrypoint script is extended by a snippet to set the privileges on the admin folder to 000 depending on an environment variable.