### PR TITLE
add support for LDAP authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN a2enmod rewrite
 
 RUN set -xe \
     && apt-get update \
-    && apt-get install -y libpng-dev libjpeg-dev libpq-dev libxml2-dev \
+    && apt-get install -y libpng-dev libjpeg-dev libpq-dev libxml2-dev libldap-dev \
     && docker-php-ext-configure gd --with-jpeg \
-    && docker-php-ext-install gd mysqli pgsql soap \
+    && docker-php-ext-install gd mysqli pgsql soap ldap \
     && rm -rf /var/lib/apt/lists/*
 
 ENV MANTIS_VER 2.24.1

--- a/README.md
+++ b/README.md
@@ -70,3 +70,23 @@ $g_smtp_connection_mode = 'tls';
 $g_smtp_username = 'mantisbt';
 $g_smtp_password = '********';
 ```
+
+## LDAP
+
+Append following to `/srv/mantis/config/config_inc.php` for LDAP
+authentication against an Active Directory server:
+
+```
+$g_login_method = LDAP;
+$g_ldap_server = 'ldap://dc.example.com';
+$g_ldap_root_dn = 'dc=example,dc=com';
+$g_ldap_bind_dn = 'cn=readuser, dc=example, dc=com';
+$g_ldap_bind_passwd = 'geheim123';
+$g_ldap_organization = '';
+$g_use_ldap_email = ON;
+$g_use_ldap_realname = ON;
+$g_ldap_protocol_version = 3;
+$g_ldap_follow_referrals = OFF;
+$g_ldap_uid_field = 'sAMAccountName';
+```
+


### PR DESCRIPTION
Here we go, split my old pull request into two, this is part two: "add support for LDAP authentication". The required ldap package will be installed and the php ldap is loaded, documentation is extended.